### PR TITLE
Fix minor error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ const svgString = sigil({
 
 ## Install
 
-SSH: `npm install git+https://git@github.com/urbit/sigil-js`
+SSH: `npm install git+ssh://git@github.com/urbit/sigil-js`
 
-HTTPS: `npm install git+ssh://git@github.com/urbit/sigil-js`
+HTTPS: `npm install git+https://git@github.com/urbit/sigil-js`
 
 ## API
 


### PR DESCRIPTION
If we want to actively discourage installing through the npm package repository, we should maybe also remove the npm version button/link from the top of the readme?

If we don't, then not sure why we offer these specifically as install instructions.