### PR TITLE
readme: use fully npm-based install

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ const svgString = sigil({
 
 ## Install
 
-SSH: `npm install git+ssh://git@github.com/urbit/sigil-js`
-
-HTTPS: `npm install git+https://git@github.com/urbit/sigil-js`
+`npm install @tlon/sigil-js`
 
 ## API
 


### PR DESCRIPTION
I used this recently and it worked fine. Think this is better than the github repo-based commands, and people have complained the existing instructions fail for them.