### PR TITLE
fixes incorrect margins on star icons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,9 @@ const sigil = (props: Config) => {
 
   if (props.margin === false || props.icon === true) {
     marginPx.x = 0;
-    marginPx.y = 0;
+    if (props.icon !== true) {
+      marginPx.y = 0;
+    }
   }
 
   // Calculate how much the symbolsGroups should change in scale. 128 is the unit size of the SVGs as drawn in their source file.


### PR DESCRIPTION
Fixes #51

I think this is fine. The rendered preview looked good with this change. In any case it identifies the problem, which is that there should be vertical margins on star icons, but not horizontal ones.