### PR TITLE
add entry point directly to core sigil function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
+
+- 2.1.0 (Feb 21, 2024)
+
+  - Adds entry point to `./src/core.ts` to export `sigil` function for non-React or non-browser-based projects.
+
 - 1.5.9 (Sep 8, 2021)
-    * Corrects typo in package.json
-    * Updates react dep to ^17
+
+  - Corrects typo in package.json
+  - Updates react dep to ^17
+
 - 1.3.7 (Nov 4, 2019)
-    * Refactors how symbols are scaled and transformed for simplicity and accuracy.
-    * Adds `reactImageRenderer`, which adds a base64 encoded background image to a react element, bypassing any recursive use of `react.createElement()`.
-    * Alters the `margin` config prop to a boolean, which toggles margin-driven layout behavior
-    * Deprecates `iconMode`
+
+  - Refactors how symbols are scaled and transformed for simplicity and accuracy.
+  - Adds `reactImageRenderer`, which adds a base64 encoded background image to a react element, bypassing any recursive use of `react.createElement()`.
+  - Alters the `margin` config prop to a boolean, which toggles margin-driven layout behavior
+  - Deprecates `iconMode`
 
 - 1.3.5 (Jul 23, 2019)
-    * Removes hard-coded inline styles and responds to #37.
+
+  - Removes hard-coded inline styles and responds to #37.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urbit/sigil-js",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbit/sigil-js",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "test": "jest",
-    "dev": "dts build && cp -a ./dist/* ./preview/lib",
+    "dev": "npm run build && cp -a ./dist/* ./preview/lib",
     "start": "dts watch",
     "build": "dts build --entry ./src/index.ts --entry ./src/core.ts",
     "lint": "dts lint",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@urbit/sigil-js",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/sigil-js.esm.js",
-  "typings": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.esm.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.esm.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./core": {
+      "require": "./dist/core.js",
+      "import": "./dist/core.esm.js",
+      "types": "./dist/core.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -36,7 +48,7 @@
     "test": "jest",
     "dev": "dts build && cp -a ./dist/* ./preview/lib",
     "start": "dts watch",
-    "build": "dts build",
+    "build": "dts build --entry ./src/index.ts --entry ./src/core.ts",
     "lint": "dts lint",
     "lint:fix": "dts lint src --fix",
     "size": "size-limit",


### PR DESCRIPTION
Adds entry point to `./src/core.ts` to export `sigil` function for non-React or non-browser-based projects.